### PR TITLE
logseq: add update script

### DIFF
--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -10,6 +10,7 @@
   copyDesktopItems,
   cctools,
   clojure,
+  darwin,
   makeDesktopItem,
   makeWrapper,
   nodejs,
@@ -150,6 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       cctools
+      darwin.autoSignDarwinBinariesHook
       xcbuild
     ];
 

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -282,6 +282,10 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postInstall
     '';
 
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
   desktopItems = [
     (makeDesktopItem {
       name = "Logseq";

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -24,15 +24,32 @@
   git,
 }:
 
+let
+  logseqVersion = "0.10.10";
+  logseqHash = "sha256-eqs6yTooN40b30jwftXMXpIt6JA9zghVb39XXXsh3Ps=";
+
+  cljsTimeRev = "5704fbf48d3478eedcf24d458c8964b3c2fd59a9";
+  cljsTimeHash = "sha256-IApL+SEm7AhbTN7J/1KiAKTx7rd53hchRh3jmPQ412g=";
+
+  bbTasksRev = "70d3edeb287f5cec7192e642549a401f7d6d4263";
+  bbTasksHash = "sha256-xVJj5XCkqfaNjnhYZkuqTSJN0ry8UVMaN44r9pxggB0=";
+
+  mavenDepsHash = "sha256-gcq9zP5AQtpZU7sC9Oq3PkTj6uDo2NSShigkcuglV98=";
+
+  yarnOfflineCacheRootHash = "sha256-bPhBvVFN7Vii5p2v3aBOkan6lsqWeYGhs4LnBdN/ETc=";
+  yarnOfflineCacheStaticResourcesHash = "sha256-xuZj2EKHxvkiDPKMLh3ZSvLT54k+buHqg9lRTFv8rNI=";
+  yarnOfflineCacheAmplifyHash = "sha256-IOhSwIf5goXCBDGHCqnsvWLf3EUPqq75xfQg55snIp4=";
+  yarnOfflineCacheTldrawHash = "sha256-CtMl3MPlyO5nWfFhCC1SLb/+1HUM3YfFATAPqJg3rUo=";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "logseq";
-  version = "0.10.10";
+  version = logseqVersion;
 
   src = fetchFromGitHub {
     owner = "logseq";
     repo = "logseq";
     tag = finalAttrs.version;
-    hash = "sha256-eqs6yTooN40b30jwftXMXpIt6JA9zghVb39XXXsh3Ps=";
+    hash = logseqHash;
   };
 
   patches = [
@@ -40,14 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
       cljs_time_src = fetchFromGitHub {
         owner = "logseq";
         repo = "cljs-time";
-        rev = "5704fbf48d3478eedcf24d458c8964b3c2fd59a9";
-        hash = "sha256-IApL+SEm7AhbTN7J/1KiAKTx7rd53hchRh3jmPQ412g=";
+        rev = cljsTimeRev;
+        hash = cljsTimeHash;
       };
       bb_tasks_src = fetchFromGitHub {
         owner = "logseq";
         repo = "bb-tasks";
-        rev = "70d3edeb287f5cec7192e642549a401f7d6d4263";
-        hash = "sha256-xVJj5XCkqfaNjnhYZkuqTSJN0ry8UVMaN44r9pxggB0=";
+        rev = bbTasksRev;
+        hash = bbTasksHash;
       };
     })
 
@@ -90,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     dontFixup = true;
 
-    outputHash = "sha256-gcq9zP5AQtpZU7sC9Oq3PkTj6uDo2NSShigkcuglV98=";
+    outputHash = mavenDepsHash;
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
   };
@@ -98,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
   yarnOfflineCacheRoot = fetchYarnDeps {
     name = "logseq-${finalAttrs.version}-yarn-deps-root";
     inherit (finalAttrs) src;
-    hash = "sha256-bPhBvVFN7Vii5p2v3aBOkan6lsqWeYGhs4LnBdN/ETc=";
+    hash = yarnOfflineCacheRootHash;
   };
 
   # ./static and ./resources are combined into ./static by the build process
@@ -107,21 +124,21 @@ stdenv.mkDerivation (finalAttrs: {
     name = "logseq-${finalAttrs.version}-yarn-deps-static-resources";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/static";
-    hash = "sha256-xuZj2EKHxvkiDPKMLh3ZSvLT54k+buHqg9lRTFv8rNI=";
+    hash = yarnOfflineCacheStaticResourcesHash;
   };
 
   yarnOfflineCacheAmplify = fetchYarnDeps {
     name = "logseq-${finalAttrs.version}-yarn-deps-amplify";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/packages/amplify";
-    hash = "sha256-IOhSwIf5goXCBDGHCqnsvWLf3EUPqq75xfQg55snIp4=";
+    hash = yarnOfflineCacheAmplifyHash;
   };
 
   yarnOfflineCacheTldraw = fetchYarnDeps {
     name = "logseq-${finalAttrs.version}-yarn-deps-tldraw";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/tldraw";
-    hash = "sha256-CtMl3MPlyO5nWfFhCC1SLb/+1HUM3YfFATAPqJg3rUo=";
+    hash = yarnOfflineCacheTldrawHash;
   };
 
   strictDeps = true;

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   fetchYarnDeps,
   replaceVars,
-  runCommand,
   writeShellScriptBin,
 
   copyDesktopItems,
@@ -26,13 +25,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "logseq";
-  version = "0.10.9-unstable-2025-03-11";
+  version = "0.10.10";
 
   src = fetchFromGitHub {
     owner = "logseq";
     repo = "logseq";
-    rev = "ac0a0dae727c46b348d0f1410138d5e49d446692";
-    hash = "sha256-esCB51BeWnni/JFL4yMKcJj5lka2+hLpcvWGify0T2o=";
+    tag = finalAttrs.version;
+    hash = "sha256-eqs6yTooN40b30jwftXMXpIt6JA9zghVb39XXXsh3Ps=";
   };
 
   patches = [
@@ -98,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   yarnOfflineCacheRoot = fetchYarnDeps {
     name = "logseq-${finalAttrs.version}-yarn-deps-root";
     inherit (finalAttrs) src;
-    hash = "sha256-z4G675kxfpmG2AJlbK5bfeUUgX7jz1ys2FlMNHJqrQ4=";
+    hash = "sha256-bPhBvVFN7Vii5p2v3aBOkan6lsqWeYGhs4LnBdN/ETc=";
   };
 
   # ./static and ./resources are combined into ./static by the build process

--- a/pkgs/by-name/lo/logseq/update.sh
+++ b/pkgs/by-name/lo/logseq/update.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash --packages curl prefetch-yarn-deps semver-tool git
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+
+# we need to manually search through tags as releases aren't really made
+# consistently upstream
+versions=$(curl -fsSL "https://api.github.com/repos/logseq/logseq/tags" | jq -r '.[].name | ltrimstr("v")')
+
+# two loops to keep it simple
+
+declare -a valid_versions
+for version in $versions; do
+  if [ "$(semver validate "$version")" = "valid" ]; then
+    valid_versions+=("$version")
+  fi
+done
+
+if [ ${#valid_versions[@]} -eq 0 ]; then
+  echo "no valid semver versions found"
+  exit 1
+fi
+
+echo "considering versions ${valid_versions[@]}"
+
+latest_version="0.0.0"
+for version in ${valid_versions[@]}; do
+  if [ "$(semver compare $latest_version $version)" = "-1" ] &&
+    [ -z "$(semver get prerel $version)" ]; then
+    latest_version=$version
+  fi
+done
+
+echo "found latest version $latest_version"
+
+# stolen from etcd
+setKV() {
+  sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" package.nix
+}
+
+nixflags=(
+  --extra-experimental-features
+  'nix-command flakes'
+)
+
+repo_info="$(
+  nix flake prefetch \
+    "${nixflags[@]}" \
+    --json "github:logseq/logseq/$latest_version"
+)"
+
+repo_hash="$(jq -r '.hash' <<<"$repo_info")"
+repo_path="$(jq -r '.storePath' <<<"$repo_info")"
+
+setKV logseqVersion "$latest_version"
+setKV logseqHash "$repo_hash"
+
+# for now, skip {cjlsTime,bbTasks}{Hash,Rev} as it will need to be manually
+# patched as well, not updated much it seems
+
+# stolen from sonic-pi
+stripwhitespace() {
+  sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+maven_hash="$(
+  nix-build "$nixpkgs" -A logseq.mavenRepo 2>&1 |
+    tail -n3 |
+    grep -F got: |
+    cut -d: -f2- |
+    stripwhitespace
+)"
+
+setKV mavenDepsHash "$maven_hash"
+
+# partially stolen from myself, #407741
+setHash() {
+  local almost_yarn_hash="$(prefetch-yarn-deps "$2/yarn.lock")"
+  local yarn_hash="$(nix "${nixflags[@]}" hash convert --hash-algo sha256 "$almost_yarn_hash")"
+
+  setKV "$1" "$yarn_hash"
+}
+
+setHash yarnOfflineCacheRootHash "$repo_path"
+setHash yarnOfflineCacheStaticResourcesHash "$repo_path/static"
+setHash yarnOfflineCacheAmplifyHash "$repo_path/packages/amplify"
+setHash yarnOfflineCacheTldrawHash "$repo_path/tldraw"


### PR DESCRIPTION
Correctly selects `0.10.0` and doesn't change hashes from what it was already.

All for ergonomics. Only thing that isn't automated is changing those revisions that were mentioned in the `hardcode-git-paths.patch`, but those don't really seem to move at all, so it's fine I guess

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
